### PR TITLE
Lix license and add keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "name": "MMM-Sonos",
   "version": "1.2.0",
-  "description": "MagicMirror module that displays playing tracks on your Sonos network",
+  "description": "MagicMirror² module that displays playing tracks on your Sonos network.",
   "author": "Thomas Bouron <tbouron@gmail.com>",
-  "license": "Apache 2.0",
+  "keywords": [
+    "sonos",
+    "music"
+  ],
+  "license": "Apache-2.0",
   "homepage": "https://github.com/tbouron/MMM-Sonos",
   "repository": {
     "type": "git",


### PR DESCRIPTION
License should be a valid [SPDX license expression](https://spdx.org/licenses/).

Keywords are used in the [new module list](https://kristjanesperanto.github.io/MagicMirror-3rd-Party-Modules/) I'm working on.